### PR TITLE
Simplify C++ parallel algorithms example

### DIFF
--- a/dot/main.cpp
+++ b/dot/main.cpp
@@ -9,7 +9,7 @@ int main(int argc, char* argv[]) {
     using std::execution::par_unseq;
     using std::vector;
 
-    const int n = 1e8;
+    const int n = 100'000'000;
     vector<double> x(n), y(n);
 
     // Initialize x and y
@@ -21,10 +21,7 @@ int main(int argc, char* argv[]) {
     // Compute dot product
     double sum = std::transform_reduce(par_unseq,
                           x.begin(), x.end(),
-                          y.begin(), 0.0, std::plus<double>(),
-                          [](const double& xi, const double& yi){
-                              return xi * yi;
-                          });
+                          y.begin(), 0.0, std::plus{}, std::multiplies{});
 
     // Assert that the sum is correct
     assert(sum == n);


### PR DESCRIPTION
I changed `const int n = 1e8;` to `const int n = 100'000'000;` because `1e8` is a floating-point constant.  C++14 lets you use a single quote character as a thousands separator in integer literals: https://en.cppreference.com/w/cpp/language/integer_literal

The `transform_reduce` call is valid C++14 code.  Here, `plus` and `multiplies` both have a default template argument `void`.  The `void` specialization of both classes has an `operator()` that deduces the types of its parameters and its return type.

Another option would be to change the lambda passed into `transform_reduce` to take its parameters `auto` instead of `const double&`.  I would do this for two reasons.

1. Specifying the parameters' types doesn't add information for readers.
2. It's better to pass small types by value, rather than by reference.